### PR TITLE
Пофиксил запуск тестов, чтобы использовалась H2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,4 +63,5 @@ task bootRunLocal(type: BootRun) {
 
 test {
     useJUnitPlatform()
+    systemProperty("spring.profiles.active", "test")
 }


### PR DESCRIPTION
До этого все-таки использовалось подключение к Postgres. Можно у себя проверить локально, что в логах дропается и создается база, используется liquibase. Если же не указывать при запуске переменные типа SPRING_DATASOURCE_USERNAME и т.п., то запуск тестов валится со следующей ошибкой:
```
java.lang.IllegalStateException: Failed to load ApplicationContext
...
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' ...
```

Я сейчас добавил для тестов параметр `spring.profiles.active` со значением `test`, аналогично тому, как это было сделано в таске bootRunLocal (там было значение `local`). Не знаю, насколько такое решение каноничное, но оно работает :)

Приветствуются любые замечания!